### PR TITLE
Fix workflow for CI run on correct reference or SHA for that event

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-      with:
-        ref: 'master'
 
     - name: Running setup
       run: bash deploy.sh setup
+
+    - name: Re-running setup with trace enabled
+      run: bash deploy.sh setup -trace
 


### PR DESCRIPTION
Signed-off-by: Prajyot Parab <prajot.parab@ibm.com>